### PR TITLE
Remove href from back link to prevent URL change;

### DIFF
--- a/templates/index.swig
+++ b/templates/index.swig
@@ -11,7 +11,7 @@
   <body ontouchstart="">
     <div id="container">
       <h1 id="titlebar">
-        <a class="back hidden" href="#"><img src="/images/left-arrow.png" height="40" width="40" /></a>
+        <a class="back hidden"><img src="/images/left-arrow.png" height="40" width="40" /></a>
         <span id="title" data-text="Universal Remote">Universal Remote</span>
       </h1>
       <ul class="remotes-nav">


### PR DESCRIPTION
When opening the remote on OS X dashboard, clicking the back button will
cause the index page to be opened in Safari. This is a result of the URL
changing which in turn is caused by the href attribute. This attribute
is however not needed and can thus be removed.
