### PR TITLE
Add a configuration feature to ignore unused keys of a remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ If you want to have the app available via port 80 and start on boot, there are e
 
 ## Configuration
 
-As of v0.0.8, ``lirc_web`` supports customization through a configuration file (``config.json``) in the root of the project. There are currently four configuration options:
+As of v0.0.8, ``lirc_web`` supports customization through a configuration file (``config.json``) in the root of the project. There are currently five configuration options:
 
 1. ``repeaters`` - buttons that repeatedly send their commands while pressed. A common example are the volume buttons on most remote controls. While you hold the volume buttons down, the remote will repeatedly send the volume command to your device.
 2. ``macros`` - a collection of commands that should be executed one after another. This allows you to automate actions like "Play Xbox 360" or "Listen to music via AirPlay". Each step in a macro is described in the format ``[ "REMOTE", "COMMAND" ]``, where ``REMOTE`` and ``COMMAND`` are defined by what you have programmed into LIRC. You can add delays between steps of macros in the format of ``[ "delay", 500 ]``. Note that the delay is measured in milliseconds so 1000 milliseconds = 1 second.
 3. ``commandLabels`` - a way to rename commands that LIRC understands (``KEY_POWER``, ``KEY_VOLUMEUP``) with labels that humans prefer (``Power``, ``Volume Up``).
 4. ``remoteLabels`` - a way to rename the remotes that LIRC understands (``XBOX360``) with labels that humans prefer (``Xbox 360``).
-
+5. ``blacklists`` - a way to ban unused keys of your remote from the GUI.
 
 #### Example config.json:
 
@@ -68,6 +68,12 @@ As of v0.0.8, ``lirc_web`` supports customization through a configuration file (
       },
       "remoteLabels": {
          "Xbox360": "Xbox 360"
+      }
+      "blacklists": {
+         "Yamaha": [
+           "AUX2",
+           "AUX3"
+         ]
       }
     }
 

--- a/app.js
+++ b/app.js
@@ -38,6 +38,8 @@ if (process.env.NODE_ENV == 'test' || process.env.NODE_ENV == 'development') {
     _init();
 }
 
+lirc_node.remotes = refineRemotes(lirc_node.remotes);
+
 function _init() {
     lirc_node.init();
 
@@ -49,6 +51,15 @@ function _init() {
         console.log("WARNING: Cannot find config.json!");
     }
 }
+
+function refineRemotes(remotes) {
+    var newRemotes = {};
+    for(remote in remotes) {
+        commands = getCommandsForRemote(remote);
+        newRemotes[remote] = commands;
+    };
+    return newRemotes;        
+} 
 
 function getCommandsForRemote(remoteName) {
     var commands = lirc_node.remotes[remoteName];
@@ -96,7 +107,7 @@ app.get('/remotes.json', function(req, res) {
 // List all commands for :remote in JSON format
 app.get('/remotes/:remote.json', function(req, res) {
     if (lirc_node.remotes[req.params.remote]) {
-        res.json(getCommandsForRemote(req.params.remote));
+        res.json(lirc_node.remotes[req.params.remote]);
     } else {
         res.send(404);
     }

--- a/app.js
+++ b/app.js
@@ -50,6 +50,23 @@ function _init() {
     }
 }
 
+function getCommandsForRemote(remoteName) {
+    var commands = lirc_node.remotes[remoteName];
+
+    if (isBlacklistExisting(remoteName)){
+        blacklist = config.blacklists[remoteName]
+        commands = commands.filter( function(command) {
+            return blacklist.indexOf(command) < 0;
+        });
+    }
+
+    return commands;
+}
+
+function isBlacklistExisting(remoteName) {
+    return config.blacklists && config.blacklists[remoteName];
+}
+
 // Routes
 
 var labelFor = labels(config.remoteLabels, config.commandLabels)
@@ -79,7 +96,7 @@ app.get('/remotes.json', function(req, res) {
 // List all commands for :remote in JSON format
 app.get('/remotes/:remote.json', function(req, res) {
     if (lirc_node.remotes[req.params.remote]) {
-        res.json(lirc_node.remotes[req.params.remote]);
+        res.json(getCommandsForRemote(req.params.remote));
     } else {
         res.send(404);
     }

--- a/app.js
+++ b/app.js
@@ -38,8 +38,6 @@ if (process.env.NODE_ENV == 'test' || process.env.NODE_ENV == 'development') {
     _init();
 }
 
-lirc_node.remotes = refineRemotes(lirc_node.remotes);
-
 function _init() {
     lirc_node.init();
 
@@ -52,31 +50,31 @@ function _init() {
     }
 }
 
-function refineRemotes(remotes) {
+function refineRemotes(myRemotes) {
+    function getCommandsForRemote(remoteName) {
+        var commands = myRemotes[remoteName];
+
+        if (isBlacklistExisting(remoteName)){
+            blacklist = config.blacklists[remoteName]
+            commands = commands.filter( function(command) {
+                return blacklist.indexOf(command) < 0;
+            });
+        }
+
+        return commands;
+    }
+
+    function isBlacklistExisting(remoteName) {
+        return config.blacklists && config.blacklists[remoteName];
+    }
+
     var newRemotes = {};
-    for(remote in remotes) {
+    for(remote in myRemotes) {
         commands = getCommandsForRemote(remote);
         newRemotes[remote] = commands;
     };
     return newRemotes;        
 } 
-
-function getCommandsForRemote(remoteName) {
-    var commands = lirc_node.remotes[remoteName];
-
-    if (isBlacklistExisting(remoteName)){
-        blacklist = config.blacklists[remoteName]
-        commands = commands.filter( function(command) {
-            return blacklist.indexOf(command) < 0;
-        });
-    }
-
-    return commands;
-}
-
-function isBlacklistExisting(remoteName) {
-    return config.blacklists && config.blacklists[remoteName];
-}
 
 // Routes
 
@@ -84,8 +82,9 @@ var labelFor = labels(config.remoteLabels, config.commandLabels)
 
 // Web UI
 app.get('/', function(req, res) {
+    var refined_remotes = refineRemotes(lirc_node.remotes);
     res.send(JST['index'].render({
-        remotes: lirc_node.remotes,
+        remotes: refined_remotes,
         macros: config.macros,
         repeaters: config.repeaters,
         labelForRemote: labelFor.remote,
@@ -101,13 +100,13 @@ app.get('/refresh', function(req, res) {
 
 // List all remotes in JSON format
 app.get('/remotes.json', function(req, res) {
-    res.json(lirc_node.remotes);
+    res.json(refineRemotes(lirc_node.remotes));
 });
 
 // List all commands for :remote in JSON format
 app.get('/remotes/:remote.json', function(req, res) {
     if (lirc_node.remotes[req.params.remote]) {
-        res.json(lirc_node.remotes[req.params.remote]);
+        res.json(refineRemotes(lirc_node.remotes)[req.params.remote]);
     } else {
         res.send(404);
     }
@@ -180,7 +179,6 @@ app.post('/macros/:macro', function(req, res) {
     res.setHeader('Cache-Control', 'no-cache');
     res.send(200);
 });
-
 
 // Default port is 3000
 app.listen(3000);

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -29,5 +29,14 @@
   },
   "remoteLabels": {
     "LircNamespace": "LIRC namespace"
+  },
+  "blacklists": {
+    "LightControl": [
+      "S2",
+      "S4",
+      "S6",
+      "S7",
+      "S8"
+    ]
   }
 }

--- a/test/fixtures/remotes.json
+++ b/test/fixtures/remotes.json
@@ -40,6 +40,16 @@
     "A",
     "B"
   ],
+  "LightControl": [
+      "S1",
+      "S2",
+      "S3",
+      "S4",
+      "S5",
+      "S6",
+      "S7",
+      "S8"
+  ],
   "LircNamespace": [
     "KEY_POWER",
     "KEY_VOLUMEUP",

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -85,19 +85,27 @@ describe('lirc_web', function() {
     });
 
     describe('json api', function() {
-        it('should return a list of all remotes (and commands) when /remotes.json is accessed', function(done) {
-            request(app)
-            .get('/remotes.json')
-            .end(function(err, res) {
-                assert.equal(res.status, 200);
-                done();
-            });
-        });
-
         var XBOX_COMMANDS = [ 'OpenClose', 'FancyButton', 'OnOff', 'Stop',
             'Pause', 'Rewind', 'FastForward', 'Prev', 'Next', 'Play',
             'Display', 'Title', 'DVD_Menu', 'Back', 'Info', 'UpArrow',
             'LeftArrow', 'RightArrow', 'DownArrow', 'OK', 'Y', 'X', 'A', 'B' ];
+
+        var LIGHT_COMMANDS = ['S1','S3','S5'];
+
+        var REFINED_REMOTES = {
+            "Yamaha": [ 'Power', 'Xbox360', 'Wii', 'VolumeUp', 'VolumeDown', 'DTV/CBL' ],
+            "SonyTV": [ 'Power', 'VolumeUp', 'VolumeDown', 'ChannelUp', 'ChannelDown' ],
+            "Xbox360" : XBOX_COMMANDS,
+            "LightControl": LIGHT_COMMANDS, 
+            "LircNamespace": [ 'KEY_POWER', 'KEY_VOLUMEUP', 'KEY_VOLUMEDOWN', 'KEY_CHANNELUP', 'KEY_CHANNELDOWN' ] 
+        };
+
+        it('should return a list of all remotes (and commands) when /remotes.json is accessed', function(done) {
+            request(app)
+            .get('/remotes.json')
+            .set('Accept', 'application/json')
+            .expect(200, REFINED_REMOTES, done);
+        });
 
         it('should return a list of all commands for a remote when /remotes/:remote.json is accessed', function(done) {
             request(app)
@@ -106,7 +114,6 @@ describe('lirc_web', function() {
             .expect(200, XBOX_COMMANDS, done)
         });
 
-        var LIGHT_COMMANDS = ['S1','S3','S5'];
         it('should return a filtered list of commands when a blacklist exists', function(done) {
             request(app)
             .get('/remotes/LightControl.json')

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -94,13 +94,24 @@ describe('lirc_web', function() {
             });
         });
 
+        var XBOX_COMMANDS = [ 'OpenClose', 'FancyButton', 'OnOff', 'Stop',
+            'Pause', 'Rewind', 'FastForward', 'Prev', 'Next', 'Play',
+            'Display', 'Title', 'DVD_Menu', 'Back', 'Info', 'UpArrow',
+            'LeftArrow', 'RightArrow', 'DownArrow', 'OK', 'Y', 'X', 'A', 'B' ];
+
         it('should return a list of all commands for a remote when /remotes/:remote.json is accessed', function(done) {
             request(app)
             .get('/remotes/Xbox360.json')
-            .end(function(err, res) {
-                assert.equal(res.status, 200);
-                done();
-            });
+            .set('Accept', 'application/json')
+            .expect(200, XBOX_COMMANDS, done)
+        });
+
+        var LIGHT_COMMANDS = ['S1','S3','S5'];
+        it('should return a filtered list of commands when a blacklist exists', function(done) {
+            request(app)
+            .get('/remotes/LightControl.json')
+            .set('Accept', 'application/json')
+            .expect(200, LIGHT_COMMANDS, done)
         });
 
         it('should return a 404 for an unknown remote', function(done) {


### PR DESCRIPTION
I want to ignore keys independent of the lirc configuration, so that I can use the complete IR layout in lirc as provided there, but only see those, that I actually use. For example, I've got a set of remote controllable power plugs. The remote control can handle up to 32 plugs with two keys each, but I only possess four plugs. So 56 keys are not used and make the automatically generated GUI really painful.

By configuring these dead keys in a blacklist, this problem is solved for me.