### PR TITLE
Added SSL functionality. Fixed example config (macros, server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,20 @@ As of v0.0.8, ``lirc_web`` supports customization through a configuration file (
 2. ``macros`` - a collection of commands that should be executed one after another. This allows you to automate actions like "Play Xbox 360" or "Listen to music via AirPlay". Each step in a macro is described in the format ``[ "REMOTE", "COMMAND" ]``, where ``REMOTE`` and ``COMMAND`` are defined by what you have programmed into LIRC. You can add delays between steps of macros in the format of ``[ "delay", 500 ]``. Note that the delay is measured in milliseconds so 1000 milliseconds = 1 second.
 3. ``commandLabels`` - a way to rename commands that LIRC understands (``KEY_POWER``, ``KEY_VOLUMEUP``) with labels that humans prefer (``Power``, ``Volume Up``).
 4. ``remoteLabels`` - a way to rename the remotes that LIRC understands (``XBOX360``) with labels that humans prefer (``Xbox 360``).
+5. ``server`` - You can configure the server here. Listener ports, and [SSL](http://serverfault.com/a/366374) settings.
 
 
 #### Example config.json:
 
 
     {
+      "server" : {
+        "port" : 3000,
+        "ssl" : false,
+        "ssl_cert" : "/home/pi/lirc_web/server.cert",
+        "ssl_key" : "/home/pi/lirc_web/server.key",
+        "ssl_port" : 3001
+      },
       "repeaters": {
         "SonyTV": {
           "VolumeUp": true,

--- a/app.js
+++ b/app.js
@@ -154,6 +154,23 @@ app.post('/macros/:macro', function(req, res) {
 });
 
 
-// Default port is 3000
-app.listen(3000);
-console.log("Open Source Universal Remote UI + API has started on port 3000.");
+// Listen (http)
+var port = 3000;
+if ( config.server && config.server.port){
+    port = config.server.port;
+}
+app.listen(port);
+console.log("Open Source Universal Remote UI + API has started on port " + port + "(http).");
+
+// Listen (https)
+if ( config.server && config.server.ssl &&  config.server.ssl_cert && config.server.ssl_key && config.server.ssl_port){
+    var https = require('https');
+    var fs = require('fs');
+    
+    var options = {
+        key: fs.readFileSync(config.server.ssl_key),
+        cert: fs.readFileSync(config.server.ssl_cert)
+    };
+    https.createServer(options, app).listen(config.server.ssl_port);
+    console.log("Open Source Universal Remote UI + API has started on port " + config.server.ssl_port + "(https).");
+}

--- a/example_configs/config.json
+++ b/example_configs/config.json
@@ -1,4 +1,11 @@
 {
+  "server" : {
+    "port" : 3000,
+    "ssl" : false,
+    "ssl_cert" : "/home/pi/lirc_web/server.cert",
+    "ssl_key" : "/home/pi/lirc_web/server.key",
+    "ssl_port" : 3001
+  },
   "repeaters": {
     "SonyTV": {
       "VolumeUp": true,
@@ -7,11 +14,11 @@
   },
   "macros": {
     "Xbox360": [
-      { "SonyTV": "Power" },
-      { "SonyTV": "Xbox360" },
-      { "Yamaha": "Power" },
-      { "Yamaha": "Xbox360" },
-      { "Xbox360": "Power" }
+      [ "SonyTV", "Power" ],
+      [ "SonyTV", "Xbox360" ],
+      [ "Yamaha", "Power" ],
+      [ "Yamaha", "Xbox360" ],
+      [ "Xbox360", "Power" ]
     ]
   },
   "commandLabels": {

--- a/templates/index.swig
+++ b/templates/index.swig
@@ -16,7 +16,7 @@
   <body ontouchstart="">
     <div id="container">
       <h1 id="titlebar">
-        <a class="back hidden"><img src="/images/left-arrow.png" height="40" width="40" /></a>
+        <a class="back hidden"><img src="images/left-arrow.png" height="40" width="40" /></a>
         <span id="title" data-text="Universal Remote">Universal Remote</span>
       </h1>
       <ul class="remotes-nav">


### PR DESCRIPTION
* Fixed example config (macros)
* Added ability to use SSL
* Added option to configure node-webserver-port
* Added new options (server) to example config

Notice:
* Still uses default port 3000, still useable without addition of new options to config.json
* All tests passed

![bildschirmfoto von 2015-12-24 21-57-56](https://cloud.githubusercontent.com/assets/6735650/11997859/83c266f6-aa89-11e5-81ea-f551d61e63bd.png)
