### PR TITLE
set home to default user home directory

### DIFF
--- a/example_configs/upstart/standalone_upstart.conf
+++ b/example_configs/upstart/standalone_upstart.conf
@@ -18,6 +18,9 @@ script
   # Should run in 'production' mode
   env NODE_ENV=production
 
+  # Set home to directory wherever your .lirc_web_config.json is located
+  export HOME="/home/pi"
+
   # File to execute, where to pipe logs
   exec lirc_web 2>&1 >> /var/log/open-source-universal-remote.upstart.log
 


### PR DESCRIPTION
Set the HOME to the user home directory fixes the issue I just submitted (#40). I added a line to the example upstart config to set HOME to the default pi user directory. 