### PR TITLE
Add ability to set lircd socket for irsend in config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These are the available configuration options:
 4. ``remoteLabels`` - a way to rename the remotes that LIRC understands (``XBOX360``) with labels that humans prefer (``Xbox 360``).
 5. ``blacklists`` - a way to hide unused commands from your remotes.
 6. ``server`` - server configuration settings (ports, [SSL](http://serverfault.com/a/366374)).
+7. ``socket`` - to specify the lircd socket for irsend.
 
 
 #### Example config.json:
@@ -86,13 +87,14 @@ These are the available configuration options:
       },
       "remoteLabels": {
          "Xbox360": "Xbox 360"
-      }
+      },
       "blacklists": {
          "Yamaha": [
            "AUX2",
            "AUX3"
          ]
-      }
+      },
+      "socket": "/run/lirc/lircd1"
     }
 
 Please see the `example_configs/` directory.
@@ -192,4 +194,3 @@ the following conditions:
 
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
-

--- a/app.js
+++ b/app.js
@@ -56,6 +56,10 @@ function _init() {
     console.log('DEBUG:', e);
     console.log('WARNING: Cannot find config.json!');
   }
+
+  if (config.socket) {
+    lircNode.setSocket(config.socket);
+  }
 }
 
 function refineRemotes(myRemotes) {


### PR DESCRIPTION
I recently installed lirc (0.9.0) on Ubuntu (15.10), the configuration prompt during installation created the /etc/lirc/hardware.conf file which included settings for a separate transmitter and receiver (I'm using two devices). When starting the lirc service, two lircd sockets are created as expected, the receiver at /run/lirc/lircd and the transmitter at /run/lirc/lircd1.
The lirc_node module exposes a `setSocket` function which allows for setting the socket for irsend commands (only). This pull request adds the ability to specify the socket via the config.json file.
Fortunately the receiver always appears to be the default socket - I haven't looked into where/why this is yet probably just the order it was written in the service script, it could be different on other operating systems in which case we might need to look at a way to specify the socket of the receiver to use with irw (and other receiving commands potentially in future) when using more than one device.