### PR TITLE
Added the ability to 'hold' buttons in Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You may place this configuration file in one of two locations and `lirc_web` wil
 These are the available configuration options:
 
 1. ``repeaters`` - buttons that repeatedly send their commands while pressed. A common example are the volume buttons on most remote controls. While you hold the volume buttons down, the remote will repeatedly send the volume command to your device.
-2. ``macros`` - a collection of commands that should be executed one after another. This allows you to automate actions like "Play Xbox 360" or "Listen to music via AirPlay". Each step in a macro is described in the format ``[ "REMOTE", "COMMAND" ]``, where ``REMOTE`` and ``COMMAND`` are defined by what you have programmed into LIRC. You can add delays between steps of macros in the format of ``[ "delay", 500 ]``. Note that the delay is measured in milliseconds so 1000 milliseconds = 1 second.
+2. ``macros`` - a collection of commands that should be executed one after another. This allows you to automate actions like "Play Xbox 360" or "Listen to music via AirPlay". Each step in a macro is described in the format ``[ "REMOTE", "COMMAND" ]``, where ``REMOTE`` and ``COMMAND`` are defined by what you have programmed into LIRC. You can add delays between steps of macros in the format of ``[ "delay", 500 ]``. Note that the delay is measured in milliseconds so 1000 milliseconds = 1 second.  You can also add a repeater macro with a delay by using the format ``[ "REMOTE", ["COMMAND", delay]]`` in place of a normal``COMMAND`` (Refer to Xbox Off command below). 
 3. ``commandLabels`` - a way to rename commands that LIRC understands (``KEY_POWER``, ``KEY_VOLUMEUP``) with labels that humans prefer (``Power``, ``Volume Up``).
 4. ``remoteLabels`` - a way to rename the remotes that LIRC understands (``XBOX360``) with labels that humans prefer (``Xbox 360``).
 5. ``blacklists`` - a way to hide unused commands from your remotes.
@@ -83,7 +83,13 @@ These are the available configuration options:
           [ "Yamaha", "Power" ],
           [ "delay", 500 ],
           [ "Yamaha", "AirPlay" ]
-        ]
+        ],
+        "Xbox Off": [
+          [ "XboxOne", [ "Power", "1600" ] ],
+          [ "delay", "1010" ],
+          [ "XboxOne", "Up" ],
+          [ "XboxOne", "Select" ]
+        ],
       },
       "commandLabels": {
         "Yamaha": {

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -3,7 +3,6 @@ function exec(macro, lircNode, iter) {
 
   // select the command from the sequence
   var command = macro[i];
-  console.log("command", command);
 
   i = i + 1;
 
@@ -16,7 +15,6 @@ function exec(macro, lircNode, iter) {
     }, command[1]);
   } else if (Array.isArray(command[1])) {
     // send_start hold command and set timeout for hold time to call send_stop
-    console.log("Command", command);
     lircNode.irsend.send_start(command[0], command[1][0], function () {
       setTimeout(function () {
         lircNode.irsend.send_stop(command[0], command[1][0], function () {

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -13,6 +13,17 @@ function exec(macro, lircNode, iter) {
     setTimeout(function () {
       exec(macro, lircNode, i);
     }, command[1]);
+  } else if (Array.isArray(command[1])) {
+    var stopSending = function() {
+      lircNode.irsend.send_stop(command[0], command[1][0], function() {
+        setTimeout(function () {
+          exec(macro, lircNode, i);
+        }, 100);
+      });
+    }
+    lircNode.irsend.send_start(command[0], command[1][0], function() {
+      setTimeout(stopSending, command[1][1]);
+    });
   } else {
     // By default, wait 100msec before calling next command
     lircNode.irsend.send_once(command[0], command[1], function () {

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -1,31 +1,41 @@
 function exec(macro, lircNode, iter) {
   var i = iter || 0;
 
-  // select the command from the sequence
-  var command = macro[i];
+  // select the macro step from the sequence
+  var macroStep = macro[i];
 
-  if (!command) { return false; }
+  // Get device as 1st parameter
+  var device = macroStep[0];
+  // Get command as 2nd parameter
+  var command = macroStep[1];
+
+  // IFF command is an array, treat as hold command, get command and hold time
+  var holdCommand = command[0];
+  var holdTime = command[1];
 
   i = i + 1;
 
-  // if the command is delay, wait N msec and then execute next command
-  if (command[0] === 'delay') {
+  if (!macroStep) { return false; }
+
+  // if the macro step is delay, wait N msec and then execute next macro step
+  if (device === 'delay') {
     setTimeout(function () {
       exec(macro, lircNode, i);
-    }, command[1]);
-  } else if (Array.isArray(command[1])) {
-    lircNode.irsend.send_start(command[0], command[1][0], function () {
+    }, command);
+  } else if (Array.isArray(command)) {
+    // send_start hold command and set timeout for hold time to call send_stop
+    lircNode.irsend.send_start(device, holdCommand, function () {
       setTimeout(function () {
-        lircNode.irsend.send_stop(command[0], command[1][0], function () {
+        lircNode.irsend.send_stop(device, holdCommand, function () {
           setTimeout(function () {
             exec(macro, lircNode, i);
           }, 100);
         });
-      }, command[1][1]);
+      }, holdTime);
     });
   } else {
-    // By default, wait 100msec before calling next command
-    lircNode.irsend.send_once(command[0], command[1], function () {
+    // By default, wait 100msec before calling next macro step
+    lircNode.irsend.send_once(device, command, function () {
       setTimeout(function () {
         exec(macro, lircNode, i);
       }, 100);

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -1,41 +1,34 @@
 function exec(macro, lircNode, iter) {
   var i = iter || 0;
 
-  // select the macro step from the sequence
-  var macroStep = macro[i];
-
-  // Get device as 1st parameter
-  var device = macroStep[0];
-  // Get command as 2nd parameter
-  var command = macroStep[1];
-
-  // IFF command is an array, treat as hold command, get command and hold time
-  var holdCommand = command[0];
-  var holdTime = command[1];
+  // select the command from the sequence
+  var command = macro[i];
+  console.log("command", command);
 
   i = i + 1;
 
-  if (!macroStep) { return false; }
+  if (!command) { return false; }
 
-  // if the macro step is delay, wait N msec and then execute next macro step
-  if (device === 'delay') {
+  // if the command is delay, wait N msec and then execute next command
+  if (command[0] === 'delay') {
     setTimeout(function () {
       exec(macro, lircNode, i);
-    }, command);
-  } else if (Array.isArray(command)) {
+    }, command[1]);
+  } else if (Array.isArray(command[1])) {
     // send_start hold command and set timeout for hold time to call send_stop
-    lircNode.irsend.send_start(device, holdCommand, function () {
+    console.log("Command", command);
+    lircNode.irsend.send_start(command[0], command[1][0], function () {
       setTimeout(function () {
-        lircNode.irsend.send_stop(device, holdCommand, function () {
+        lircNode.irsend.send_stop(command[0], command[1][0], function () {
           setTimeout(function () {
             exec(macro, lircNode, i);
           }, 100);
         });
-      }, holdTime);
+      }, command[1][1]);
     });
   } else {
-    // By default, wait 100msec before calling next macro step
-    lircNode.irsend.send_once(device, command, function () {
+    // By default, wait 100msec before calling next command
+    lircNode.irsend.send_once(command[0], command[1], function () {
       setTimeout(function () {
         exec(macro, lircNode, i);
       }, 100);

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -14,15 +14,14 @@ function exec(macro, lircNode, iter) {
       exec(macro, lircNode, i);
     }, command[1]);
   } else if (Array.isArray(command[1])) {
-    var stopSending = function() {
-      lircNode.irsend.send_stop(command[0], command[1][0], function() {
-        setTimeout(function () {
-          exec(macro, lircNode, i);
-        }, 100);
-      });
-    }
-    lircNode.irsend.send_start(command[0], command[1][0], function() {
-      setTimeout(stopSending, command[1][1]);
+    lircNode.irsend.send_start(command[0], command[1][0], function () {
+      setTimeout(function () {
+        lircNode.irsend.send_stop(command[0], command[1][0], function () {
+          setTimeout(function () {
+            exec(macro, lircNode, i);
+          }, 100);
+        });
+      }, command[1][1]);
     });
   } else {
     // By default, wait 100msec before calling next command

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -13,6 +13,11 @@
       [ "Yamaha", "Xbox360" ],
       [ "Xbox360", "Power" ]
     ],
+    "XboxOne Off": [
+      [ "XboxOne", ["Power", 1600]],
+      [ "XboxOne", "Up"],
+      [ "XboxOne", "Select"]
+    ],
     "Listen to Music / Jams": [
       [ "Yamaha", "Power" ],
       [ "Yamaha", "AirPlay" ]

--- a/test/fixtures/remotes.json
+++ b/test/fixtures/remotes.json
@@ -40,6 +40,11 @@
     "A",
     "B"
   ],
+  "XboxOne": [
+    "Power",
+    "Up",
+    "Select"
+  ],
   "LightControl": [
       "S1",
       "S2",

--- a/test/lib/macros.js
+++ b/test/lib/macros.js
@@ -16,8 +16,19 @@ describe('macros', function () {
     lircNode = {};
     lircNode.irsend = {};
     lircNode.irsend.send_once = function () {};
+    lircNode.irsend.send_start = function () {};
+    lircNode.irsend.send_stop = function () {};
 
-    stub = sinon.stub(lircNode.irsend, 'send_once', function (remote, command, cb) {
+
+    send_once_stub = sinon.stub(lircNode.irsend, 'send_once', function (remote, command, cb) {
+      cb();
+    });
+
+    send_start_stub = sinon.stub(lircNode.irsend, 'send_start', function (remote, command, cb) {
+      cb();
+    });
+
+    send_stop_stub = sinon.stub(lircNode.irsend, 'send_stop', function (remote, command, cb) {
       cb();
     });
 
@@ -34,29 +45,48 @@ describe('macros', function () {
     it('should call lircNode.irsend.send_once when executing a macro', function () {
       macros.exec(config.macros['Play Xbox 360'], lircNode);
 
-      assert.equal(stub.called, true);
+      assert.equal(send_once_stub.called, true);
     });
 
     it('should delay when encountering a delay', function () {
       macros.exec(config.macros['Macro With Delay'], lircNode);
 
-      assert.equal(stub.called, false);
+      assert.equal(send_once_stub.called, false);
 
-      // not enough time has passed, stub should not have been called
+      // not enough time has passed, send_once_stub should not have been called
       clock.tick(250);
-      assert.equal(stub.called, false);
+      assert.equal(send_once_stub.called, false);
 
       // enough time has now passed, macro should have tried to execute next command
       clock.tick(250);
-      assert.equal(stub.called, true);
+      assert.equal(send_once_stub.called, true);
     });
 
     it('should call send_once once per command', function () {
       macros.exec(config.macros['Play Xbox 360'], lircNode);
       // wait enough time
       clock.tick(500);
+      console.log("Count", send_once_stub.callCount);
+      assert.equal(send_once_stub.callCount, 5);
+    });
 
-      assert.equal(stub.callCount, 5);
+    it('should call send_start and send_stop at least once', function () {
+      macros.exec(config.macros['XboxOne Off'], lircNode);
+
+      assert.equal(send_start_stub.called, true);
+
+      // send_stop_stub shouldn't have been called yet
+      assert.equal(send_stop_stub.called, false);
+
+      // wait
+      clock.tick(1600);
+
+      assert.equal(send_stop_stub.called, true);
+
+      // Wait some more before checking the last methods were called
+      clock.tick(200);
+      assert.equal(send_once_stub.callCount, 2);
+
     });
   });
 });

--- a/test/lib/macros.js
+++ b/test/lib/macros.js
@@ -8,7 +8,10 @@ var config = require('../fixtures/config.json');
 describe('macros', function () {
   var lircNode;
   var clock;
-  var stub;
+  var sendOnceStub;
+  var sendStartStub;
+  var sendStopStub;
+
 
   beforeEach(function (done) {
     clock = sinon.useFakeTimers();
@@ -20,15 +23,15 @@ describe('macros', function () {
     lircNode.irsend.send_stop = function () {};
 
 
-    send_once_stub = sinon.stub(lircNode.irsend, 'send_once', function (remote, command, cb) {
+    sendOnceStub = sinon.stub(lircNode.irsend, 'send_once', function (remote, command, cb) {
       cb();
     });
 
-    send_start_stub = sinon.stub(lircNode.irsend, 'send_start', function (remote, command, cb) {
+    sendStartStub = sinon.stub(lircNode.irsend, 'send_start', function (remote, command, cb) {
       cb();
     });
 
-    send_stop_stub = sinon.stub(lircNode.irsend, 'send_stop', function (remote, command, cb) {
+    sendStopStub = sinon.stub(lircNode.irsend, 'send_stop', function (remote, command, cb) {
       cb();
     });
 
@@ -45,48 +48,46 @@ describe('macros', function () {
     it('should call lircNode.irsend.send_once when executing a macro', function () {
       macros.exec(config.macros['Play Xbox 360'], lircNode);
 
-      assert.equal(send_once_stub.called, true);
+      assert.equal(sendOnceStub.called, true);
     });
 
     it('should delay when encountering a delay', function () {
       macros.exec(config.macros['Macro With Delay'], lircNode);
 
-      assert.equal(send_once_stub.called, false);
+      assert.equal(sendOnceStub.called, false);
 
-      // not enough time has passed, send_once_stub should not have been called
+      // not enough time has passed, sendOnceStub should not have been called
       clock.tick(250);
-      assert.equal(send_once_stub.called, false);
+      assert.equal(sendOnceStub.called, false);
 
       // enough time has now passed, macro should have tried to execute next command
       clock.tick(250);
-      assert.equal(send_once_stub.called, true);
+      assert.equal(sendOnceStub.called, true);
     });
 
     it('should call send_once once per command', function () {
       macros.exec(config.macros['Play Xbox 360'], lircNode);
       // wait enough time
       clock.tick(500);
-      console.log("Count", send_once_stub.callCount);
-      assert.equal(send_once_stub.callCount, 5);
+      assert.equal(sendOnceStub.callCount, 5);
     });
 
     it('should call send_start and send_stop at least once', function () {
       macros.exec(config.macros['XboxOne Off'], lircNode);
 
-      assert.equal(send_start_stub.called, true);
+      assert.equal(sendStartStub.called, true);
 
-      // send_stop_stub shouldn't have been called yet
-      assert.equal(send_stop_stub.called, false);
+      // sendStopStub shouldn't have been called yet
+      assert.equal(sendStopStub.called, false);
 
       // wait
       clock.tick(1600);
 
-      assert.equal(send_stop_stub.called, true);
+      assert.equal(sendStopStub.called, true);
 
       // Wait some more before checking the last methods were called
       clock.tick(200);
-      assert.equal(send_once_stub.callCount, 2);
-
+      assert.equal(sendOnceStub.callCount, 2);
     });
   });
 });

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -8,7 +8,7 @@ var jquery = fs.readFileSync('node_modules/jquery/dist/jquery.js', 'utf-8');
 describe('lirc_web', function () {
   describe('routes', function () {
     // Root route
-    it('should have an index route "/"', function (done) {
+    it('should have an index route \'/\'', function (done) {
       assert(request(app).get('/').expect(200, done));
     });
 
@@ -115,7 +115,7 @@ describe('lirc_web', function () {
       SonyTV: ['Power', 'VolumeUp', 'VolumeDown', 'ChannelUp', 'ChannelDown'],
       Xbox360: XBOX_COMMANDS,
       LightControl: LIGHT_COMMANDS,
-      XboxOne: ["Power", "Up", "Select"],
+      XboxOne: ['Power', 'Up', 'Select'],
       LircNamespace: ['KEY_POWER', 'KEY_VOLUMEUP', 'KEY_VOLUMEDOWN', 'KEY_CHANNELUP', 'KEY_CHANNELDOWN'],
     };
 

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -115,6 +115,7 @@ describe('lirc_web', function () {
       SonyTV: ['Power', 'VolumeUp', 'VolumeDown', 'ChannelUp', 'ChannelDown'],
       Xbox360: XBOX_COMMANDS,
       LightControl: LIGHT_COMMANDS,
+      XboxOne: ["Power", "Up", "Select"],
       LircNamespace: ['KEY_POWER', 'KEY_VOLUMEUP', 'KEY_VOLUMEDOWN', 'KEY_CHANNELUP', 'KEY_CHANNELDOWN'],
     };
 

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -8,7 +8,7 @@ var jquery = fs.readFileSync('node_modules/jquery/dist/jquery.js', 'utf-8');
 describe('lirc_web', function () {
   describe('routes', function () {
     // Root route
-    it('should have an index route \'/\'', function (done) {
+    it('should have an index route "/"', function (done) {
       assert(request(app).get('/').expect(200, done));
     });
 


### PR DESCRIPTION
Added in the ability to use repeater's in macro's.  Certain remote functions, like powering off an Xbox One, require a button to be 'held' for a period of time, along with other commands.  

Macro function modified to check to see if ``COMMAND`` is an array type, if so it treats its elements as ``COMMAND``, and ``DELAY``, and issues a `send_start` and `send_stop` accordingly.

In the future, this logic should probably be cleaned up to use objects for better semantics and type safety.