### PR TITLE
Exposes remote / commands labels in remotes API

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,14 +90,20 @@ function refineRemotes(myRemotes) {
       });
     }
 
+    remoteCommands = remoteCommands.map(function (command) {
+      return { name: command, label: labelFor.command(remote, command) };
+    });
+
     return remoteCommands;
   }
 
   for (remote in myRemotes) {
     newRemoteCommands = getCommandsForRemote(remote);
-    newRemotes[remote] = newRemoteCommands;
+    newRemotes[remote] = {
+      label: labelFor.remote(remote),
+      commands: newRemoteCommands,
+    };
   }
-
   return newRemotes;
 }
 
@@ -121,8 +127,6 @@ app.get('/', function (req, res) {
     remotes: refinedRemotes,
     macros: config.macros,
     repeaters: config.repeaters,
-    labelForRemote: labelFor.remote,
-    labelForCommand: labelFor.command,
   }));
 });
 

--- a/templates/index.swig
+++ b/templates/index.swig
@@ -22,7 +22,7 @@
       <ul class="remotes-nav">
       {% for remote in remotes %}
         {% set remoteName = loop.key %}
-        <li><a class="btn btn-wide btn-large btn-info" href="#{{ remoteName }}">{{ labelForRemote(remoteName) }}</a></li>
+        <li><a class="btn btn-wide btn-large btn-info" href="#{{ remoteName }}">{{ remote.label }}</a></li>
       {% endfor %}
       </ul>
 
@@ -43,9 +43,9 @@
         {% set remoteName = loop.key %}
         <li class="remote" id="{{ remoteName }}">
           <ul class="commands">
-          {% for command in remote %}
+          {% for command in remote.commands %}
              <li class="command">
-               <button class="command-link {% if repeaters[remoteName] && repeaters[remoteName][command] %}command-repeater{% else %}command-once{% endif %} btn btn-wide btn-large btn-primary" href="/remotes/{{ remoteName|url_encode }}/{{ command|url_encode }}">{{ labelForCommand(remoteName, command) }}</button>
+               <button class="command-link {% if repeaters[remoteName] && repeaters[remoteName][command.name] %}command-repeater{% else %}command-once{% endif %} btn btn-wide btn-large btn-primary" href="/remotes/{{ remoteName|url_encode }}/{{ command.name|url_encode }}">{{ command.label }}</button>
              </li>
           {% endfor %}
           </ul>

--- a/test/lirc_web.js
+++ b/test/lirc_web.js
@@ -103,20 +103,87 @@ describe('lirc_web', function () {
   });
 
   describe('json api', function () {
-    var XBOX_COMMANDS = ['OpenClose', 'FancyButton', 'OnOff', 'Stop',
-      'Pause', 'Rewind', 'FastForward', 'Prev', 'Next', 'Play',
-      'Display', 'Title', 'DVD_Menu', 'Back', 'Info', 'UpArrow',
-      'LeftArrow', 'RightArrow', 'DownArrow', 'OK', 'Y', 'X', 'A', 'B'];
+    var XBOX_REMOTE = {
+      label: 'Xbox360',
+      commands: [
+        { name: 'OpenClose', label: 'OpenClose' },
+        { name: 'FancyButton', label: 'FancyButton' },
+        { name: 'OnOff', label: 'OnOff' },
+        { name: 'Stop', label: 'Stop' },
+        { name: 'Pause', label: 'Pause' },
+        { name: 'Rewind', label: 'Rewind' },
+        { name: 'FastForward', label: 'FastForward' },
+        { name: 'Prev', label: 'Prev' },
+        { name: 'Next', label: 'Next' },
+        { name: 'Play', label: 'Play' },
+        { name: 'Display', label: 'Display' },
+        { name: 'Title', label: 'Title' },
+        { name: 'DVD_Menu', label: 'DVD_Menu' },
+        { name: 'Back', label: 'Back' },
+        { name: 'Info', label: 'Info' },
+        { name: 'UpArrow', label: 'UpArrow' },
+        { name: 'LeftArrow', label: 'LeftArrow' },
+        { name: 'RightArrow', label: 'RightArrow' },
+        { name: 'DownArrow', label: 'DownArrow' },
+        { name: 'OK', label: 'OK' },
+        { name: 'Y', label: 'Y' },
+        { name: 'X', label: 'X' },
+        { name: 'A', label: 'A' },
+        { name: 'B', label: 'B' },
+      ],
+    };
 
-    var LIGHT_COMMANDS = ['S1', 'S3', 'S5'];
+    var LIGHT_REMOTE = {
+      label: 'LightControl',
+      commands: [
+        { name: 'S1', label: 'S1' },
+        { name: 'S3', label: 'S3' },
+        { name: 'S5', label: 'S5' },
+      ],
+    };
 
     var REFINED_REMOTES = {
-      Yamaha: ['Power', 'Xbox360', 'Wii', 'VolumeUp', 'VolumeDown', 'DTV/CBL'],
-      SonyTV: ['Power', 'VolumeUp', 'VolumeDown', 'ChannelUp', 'ChannelDown'],
-      Xbox360: XBOX_COMMANDS,
-      LightControl: LIGHT_COMMANDS,
-      XboxOne: ['Power', 'Up', 'Select'],
-      LircNamespace: ['KEY_POWER', 'KEY_VOLUMEUP', 'KEY_VOLUMEDOWN', 'KEY_CHANNELUP', 'KEY_CHANNELDOWN'],
+      Yamaha: {
+        label: 'Yamaha',
+        commands: [
+          { name: 'Power', label: 'Power' },
+          { name: 'Xbox360', label: 'Xbox360' },
+          { name: 'Wii', label: 'Wii' },
+          { name: 'VolumeUp', label: 'VolumeUp' },
+          { name: 'VolumeDown', label: 'VolumeDown' },
+          { name: 'DTV/CBL', label: 'DTV/CBL' },
+        ],
+      },
+      SonyTV: {
+        label: 'SonyTV',
+        commands: [
+          { name: 'Power', label: 'Power' },
+          { name: 'VolumeUp', label: 'VolumeUp' },
+          { name: 'VolumeDown', label: 'VolumeDown' },
+          { name: 'ChannelUp', label: 'ChannelUp' },
+          { name: 'ChannelDown', label: 'ChannelDown' },
+        ],
+      },
+      Xbox360: XBOX_REMOTE,
+      LightControl: LIGHT_REMOTE,
+      XboxOne: {
+        label: 'XboxOne',
+        commands: [
+          { name: 'Power', label: 'Power' },
+          { name: 'Up', label: 'Up' },
+          { name: 'Select', label: 'Select' },
+        ],
+      },
+      LircNamespace: {
+        label: 'LIRC namespace',
+        commands: [
+          { name: 'KEY_POWER', label: 'Power' },
+          { name: 'KEY_VOLUMEUP', label: 'Vol+' },
+          { name: 'KEY_VOLUMEDOWN', label: 'Vol-' },
+          { name: 'KEY_CHANNELUP', label: 'Channel Up' },
+          { name: 'KEY_CHANNELDOWN', label: 'Channel Down' },
+        ],
+      },
     };
 
     it('should return a list of all remotes (and commands) when /remotes.json is accessed', function (done) {
@@ -130,14 +197,14 @@ describe('lirc_web', function () {
       request(app)
       .get('/remotes/Xbox360.json')
       .set('Accept', 'application/json')
-      .expect(200, XBOX_COMMANDS, done);
+      .expect(200, XBOX_REMOTE, done);
     });
 
     it('should return a filtered list of commands when a blacklist exists', function (done) {
       request(app)
       .get('/remotes/LightControl.json')
       .set('Accept', 'application/json')
-      .expect(200, LIGHT_COMMANDS, done);
+      .expect(200, LIGHT_REMOTE, done);
     });
 
     it('should return a 404 for an unknown remote', function (done) {


### PR DESCRIPTION
This is a breaking change in the format of objects returned by the `/remotes.json` and `/remotes/:name.json` endpoints.

It basically includes the label of the remotes and their commands in a structured object.

Resolves #53.
