### PR TITLE
Added support for simulate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ These are the available configuration options:
 5. ``blacklists`` - a way to hide unused commands from your remotes.
 6. ``server`` - server configuration settings (ports, [SSL](http://serverfault.com/a/366374)).
 7. ``socket`` - to specify the lircd socket for irsend.
+8. ``simulators`` - a list of remotes that should use the 'simulate' command. This list can contain any remote inside of the lircd.conf file.
 
 
 #### Example config.json:
@@ -108,7 +109,11 @@ These are the available configuration options:
            "AUX3"
          ]
       },
-      "socket": "/run/lirc/lircd1"
+      "socket": "/run/lirc/lircd1",
+			"simulators":[
+				"Outlets",
+				"Plugs"
+			]
     }
 
 Please see the `example_configs/` directory.

--- a/app.js
+++ b/app.js
@@ -117,6 +117,8 @@ labelFor = labels(config.remoteLabels, config.commandLabels);
 // Index
 app.get('/', function (req, res) {
   var refinedRemotes = refineRemotes(lircNode.remotes);
+	
+	console.log(refinedRemotes);
   res.send(JST.index({
     remotes: refinedRemotes,
     macros: config.macros,
@@ -170,7 +172,15 @@ app.get('/macros/:macro.json', function (req, res) {
 
 // Send :remote/:command one time
 app.post('/remotes/:remote/:command', function (req, res) {
-  lircNode.irsend.send_once(req.params.remote, req.params.command, function () {});
+	
+	if(config.simulators.includes(req.params.remote))
+	{
+		console.log("This is a remote that should be simulated");
+		lircNode.irsend.simulate("0000000000000000 00 " + req.params.command + " " + req.params.remote);
+	}
+	else
+		lircNode.irsend.send_once(req.params.remote, req.params.command, function () {});
+	
   res.setHeader('Cache-Control', 'no-cache');
   res.sendStatus(200);
 });
@@ -193,7 +203,7 @@ app.post('/remotes/:remote/:command/send_stop', function (req, res) {
 app.post('/macros/:macro', function (req, res) {
   // If the macro exists, execute it
   if (config.macros && config.macros[req.params.macro]) {
-    macros.exec(config.macros[req.params.macro], lircNode);
+    macros.exec(config.macros[req.params.macro], lircNode, config.simulators);
     res.setHeader('Cache-Control', 'no-cache');
     res.sendStatus(200);
   } else {

--- a/lib/macros.js
+++ b/lib/macros.js
@@ -1,36 +1,32 @@
-function exec(macro, lircNode, iter) {
+function exec(macro, lircNode, simulators, iter) {
   var i = iter || 0;
 
+	var callback = function()
+	{
+		setTimeout(function () {
+			exec(macro, lircNode, simulators, i);
+		}, 100);
+	}
+	
   // select the command from the sequence
   var command = macro[i];
 
-  i = i + 1;
-
   if (!command) { return false; }
+
+  i = i + 1;
 
   // if the command is delay, wait N msec and then execute next command
   if (command[0] === 'delay') {
-    setTimeout(function () {
-      exec(macro, lircNode, i);
-    }, command[1]);
-  } else if (Array.isArray(command[1])) {
-    // send_start hold command and set timeout for hold time to call send_stop
-    lircNode.irsend.send_start(command[0], command[1][0], function () {
-      setTimeout(function () {
-        lircNode.irsend.send_stop(command[0], command[1][0], function () {
-          setTimeout(function () {
-            exec(macro, lircNode, i);
-          }, 100);
-        });
-      }, command[1][1]);
-    });
+    setTimeout(callback, command[1]);
   } else {
     // By default, wait 100msec before calling next command
-    lircNode.irsend.send_once(command[0], command[1], function () {
-      setTimeout(function () {
-        exec(macro, lircNode, i);
-      }, 100);
-    });
+		if(simulators.includes(command[0]))
+		{
+			console.log("This is a remote that should be simulated");
+			lircNode.irsend.simulate("0000000000000000 00 " + command[1] + " " + command[0], callback);
+		}
+		else
+			lircNode.irsend.send_once(command[0], command[1], callback)
   }
 
   return true;


### PR DESCRIPTION
> A new configuration option is added to allow you to inform lirc_web that a remote within lirc should be referenced as a simulated device.
> +Updated the marcros.js file to allow simulated devices to be a part of a macro.
> +Minimal changes to systems, everything works the same, but now you can use simulated devices.
> +Updated README.md

For this to work, lirc needs to be setup with some commands to simulate. Within your lircd.conf you need a remote similar to this:
[remote.conf.txt](https://github.com/alexbain/lirc_web/files/3169125/remote.conf.txt)

You must have an lircrc file setup that looks similar to the following file (note the file shouldn't have any extension, github wouldn't allow me to upload without a file extension). This file should be located in /etc/lirc/
[lircrc.txt](https://github.com/alexbain/lirc_web/files/3169128/lircrc.txt)

[This post](https://www.raspberrypi.org/forums/viewtopic.php?t=66946&p=507171) by the raspberry pi foundation does a great job explaining how to setup lirc to support simulated commands.

Issues I had while coming up with this solution...

1. lirc changed from what I knew it as. lirc_options.conf is your friend.
2. lirc_node is partially broken, you need to update it like [I mention in this issue.](https://github.com/alexbain/lirc_web/issues/58)
3. irexec doesn't seem to load the lircrc file out of /etc/lirc/, so I have been needing to manually start it with this command: `sudo irexec -d /etc/lirc/lircrc`
4. You can manually test a simulate command by running something like this from the CLI: `irsend SIMULATE "00000000000005d0 00 <COMMAND> <REMOTE>`